### PR TITLE
Replace abort handler with generic result handler

### DIFF
--- a/examples/git.go
+++ b/examples/git.go
@@ -16,12 +16,17 @@ func main() {
 	p.WithSteps(
 		predicate.ToStep("clone repository", CloneGitRepository(), predicate.Not(DirExists("my-repo"))),
 		pipeline.NewStep("checkout branch", CheckoutBranch()),
-		pipeline.NewStep("pull", Pull()),
+		pipeline.NewStep("pull", Pull()).WithResultHandler(logSuccess),
 	)
 	result := p.Run()
 	if !result.IsSuccessful() {
 		log.Fatal(result.Err)
 	}
+}
+
+func logSuccess(result pipeline.Result) error {
+	log.Println("handler called")
+	return result.Err
 }
 
 func CloneGitRepository() pipeline.ActionFunc {


### PR DESCRIPTION
## Summary

A bool flag never felt like the right way to abort a pipeline even in non-error cases.

The new Result handler is now always called if a step has one, which makes error handling much easier

Additionally, the Result struct has a new property 'Name' that allows easy identification in handlers.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
