### PR TITLE
Replace Logger with Hooks

### DIFF
--- a/examples/hooks_test.go
+++ b/examples/hooks_test.go
@@ -1,0 +1,35 @@
+//+build examples
+
+package examples
+
+import (
+	"fmt"
+	"testing"
+
+	pipeline "github.com/ccremer/go-command-pipeline"
+)
+
+type PipelineLogger struct{}
+
+func (l *PipelineLogger) Accept(step pipeline.Step) {
+	fmt.Println(fmt.Sprintf("Executing step: %s", step.Name))
+}
+
+func TestExample_Hooks(t *testing.T) {
+	p := pipeline.NewPipeline()
+	p.AddBeforeHook(&PipelineLogger{})
+	p.WithSteps(
+		pipeline.NewStep("hook demo", AfterHookAction()),
+	)
+	result := p.Run()
+	if !result.IsSuccessful() {
+		t.Fatal(result.Err)
+	}
+}
+
+func AfterHookAction() pipeline.ActionFunc {
+	return func(ctx pipeline.Context) pipeline.Result {
+		fmt.Println("I am called in an action after the hooks")
+		return pipeline.Result{}
+	}
+}


### PR DESCRIPTION
## Summary

The "logging" feature felt out of place. At its core, it is nothing but a function with only 1 specialized usage.
Thus the idea came to mind where the logger is now replaced with a slice of `Listener`, where each listener gets invoked before executing a step's ActionFunc

* Add new Interface `Listener`
* Add new funcs `WithBeforeHooks` and `AddBeforeHook`

Breaking changes:
* func `NewPipelineWithLogger` is removed
* interface `Logger` is removed

An example of using logging with hooks is given in https://github.com/ccremer/go-command-pipeline/blob/93706053ef61131d453721604d051f13c447abd2/examples/hooks_test.go

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
