### PR TITLE
Add pipeline finalizer

### DIFF
--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -22,6 +22,7 @@ func TestPipeline_Run(t *testing.T) {
 	tests := map[string]struct {
 		givenSteps        []Step
 		givenBeforeHook   Listener
+		givenFinalizer    ResultHandler
 		expectErrorString string
 		expectedCalls     int
 	}{
@@ -43,6 +44,13 @@ func TestPipeline_Run(t *testing.T) {
 			},
 			givenBeforeHook: hook,
 			expectedCalls:   2,
+		},
+		"GivenPipelineWithFinalizer_WhenRunning_ThenCallHandler": {
+			givenFinalizer: func(result Result) error {
+				callCount += 1
+				return nil
+			},
+			expectedCalls: 1,
 		},
 		"GivenSingleStepWithoutHandler_WhenRunningWithError_ThenReturnError": {
 			givenSteps: []Step{
@@ -118,6 +126,7 @@ func TestPipeline_Run(t *testing.T) {
 			callCount = 0
 			p := &Pipeline{}
 			p.WithSteps(tt.givenSteps...)
+			p.WithFinalizer(tt.givenFinalizer)
 			if tt.givenBeforeHook != nil {
 				p.AddBeforeHook(tt.givenBeforeHook)
 			}

--- a/result.go
+++ b/result.go
@@ -1,0 +1,11 @@
+package pipeline
+
+// IsSuccessful returns true if the contained error is nil.
+func (r Result) IsSuccessful() bool {
+	return r.Err == nil
+}
+
+// IsFailed returns true if the contained error is non-nil.
+func (r Result) IsFailed() bool {
+	return r.Err != nil
+}

--- a/step.go
+++ b/step.go
@@ -1,0 +1,23 @@
+package pipeline
+
+// NewStep returns a new Step with given name and action.
+func NewStep(name string, action ActionFunc) Step {
+	return Step{
+		Name: name,
+		F:    action,
+	}
+}
+
+// NewStepFromFunc returns a new Step with given name using a function that expects an error.
+func NewStepFromFunc(name string, fn func(ctx Context) error) Step {
+	return NewStep(name, func(ctx Context) Result {
+		err := fn(ctx)
+		return Result{Err: err, Name: name}
+	})
+}
+
+// WithResultHandler sets the ResultHandler of this specific step and returns the step itself.
+func (s Step) WithResultHandler(handler ResultHandler) Step {
+	s.H = handler
+	return s
+}


### PR DESCRIPTION

## Summary

The pipeline lacked a feature where the last result isn't interceptable.
This is mainly used in nested pipelines (e.g. parallel)

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
