### PR TITLE
Add Context to predicate and result handlers

### DIFF
--- a/examples/git_test.go
+++ b/examples/git_test.go
@@ -25,7 +25,7 @@ func TestExample_Git(t *testing.T) {
 	}
 }
 
-func logSuccess(result pipeline.Result) error {
+func logSuccess(ctx pipeline.Context, result pipeline.Result) error {
 	log.Println("handler called")
 	return result.Err
 }
@@ -60,7 +60,7 @@ func execGitCommand(args ...string) error {
 }
 
 func DirExists(path string) predicate.Predicate {
-	return func(step pipeline.Step) bool {
+	return func(ctx pipeline.Context, step pipeline.Step) bool {
 		if info, err := os.Stat(path); err != nil || !info.IsDir() {
 			return false
 		}

--- a/parallel/fanout.go
+++ b/parallel/fanout.go
@@ -12,10 +12,11 @@ The function provided as PipelineSupplier is expected to close the given channel
 The step waits until all pipelines are finished.
 If the given ResultHandler is non-nil it will be called after all pipelines were run, otherwise the step is considered successful.
 The given pipelines have to define their own pipeline.Context, it's not passed "down" from parent pipeline.
+However, The pipeline.Context for the ResultHandler will be the one from parent pipeline.
 */
 func NewFanOutStep(name string, pipelineSupplier PipelineSupplier, handler ResultHandler) pipeline.Step {
 	step := pipeline.Step{Name: name}
-	step.F = func(_ pipeline.Context) pipeline.Result {
+	step.F = func(ctx pipeline.Context) pipeline.Result {
 		pipelineChan := make(chan *pipeline.Pipeline)
 		m := sync.Map{}
 		var wg sync.WaitGroup
@@ -34,7 +35,7 @@ func NewFanOutStep(name string, pipelineSupplier PipelineSupplier, handler Resul
 		}
 
 		wg.Wait()
-		return collectResults(handler, &m)
+		return collectResults(ctx, handler, &m)
 	}
 	return step
 }

--- a/parallel/fanout_test.go
+++ b/parallel/fanout_test.go
@@ -29,7 +29,7 @@ func TestNewFanOutStep(t *testing.T) {
 		"GivenPipelineWith_WhenRunningStep_ThenReturnSuccessButRunErrorHandler": {
 			jobs:      1,
 			returnErr: fmt.Errorf("should be called"),
-			givenResultHandler: func(_ map[uint64]pipeline.Result) pipeline.Result {
+			givenResultHandler: func(ctx pipeline.Context, _ map[uint64]pipeline.Result) pipeline.Result {
 				atomic.AddUint64(&counts, 1)
 				return pipeline.Result{}
 			},
@@ -41,7 +41,7 @@ func TestNewFanOutStep(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			handler := tt.givenResultHandler
 			if handler == nil {
-				handler = func(results map[uint64]pipeline.Result) pipeline.Result {
+				handler = func(ctx pipeline.Context, results map[uint64]pipeline.Result) pipeline.Result {
 					assert.NoError(t, results[0].Err)
 					return pipeline.Result{}
 				}
@@ -75,7 +75,7 @@ func ExampleNewFanOutStep() {
 				return pipeline.Result{}
 			}))
 		}
-	}, func(results map[uint64]pipeline.Result) pipeline.Result {
+	}, func(ctx pipeline.Context, results map[uint64]pipeline.Result) pipeline.Result {
 		for worker, result := range results {
 			if result.IsFailed() {
 				fmt.Println(fmt.Sprintf("Worker %d failed: %v", worker, result.Err))

--- a/parallel/pool.go
+++ b/parallel/pool.go
@@ -16,13 +16,14 @@ The step waits until all pipelines are finished.
  * If size is 1, the pipelines are effectively run in sequence.
  * If size is 0 or less, the function panics.
 The given pipelines have to define their own pipeline.Context, it's not passed "down" from parent pipeline.
+However, The pipeline.Context for the ResultHandler will be the one from parent pipeline.
 */
 func NewWorkerPoolStep(name string, size int, pipelineSupplier PipelineSupplier, handler ResultHandler) pipeline.Step {
 	if size < 1 {
 		panic("pool size cannot be lower than 1")
 	}
 	step := pipeline.Step{Name: name}
-	step.F = func(_ pipeline.Context) pipeline.Result {
+	step.F = func(ctx pipeline.Context) pipeline.Result {
 		pipelineChan := make(chan *pipeline.Pipeline, size)
 		m := sync.Map{}
 		var wg sync.WaitGroup
@@ -35,7 +36,7 @@ func NewWorkerPoolStep(name string, size int, pipelineSupplier PipelineSupplier,
 		}
 
 		wg.Wait()
-		return collectResults(handler, &m)
+		return collectResults(ctx, handler, &m)
 	}
 	return step
 }

--- a/parallel/pool_test.go
+++ b/parallel/pool_test.go
@@ -41,7 +41,7 @@ func TestNewWorkerPoolStep(t *testing.T) {
 					atomic.AddUint64(&counts, 1)
 					return pipeline.Result{Err: tt.expectedError}
 				}))
-			}, func(results map[uint64]pipeline.Result) pipeline.Result {
+			}, func(ctx pipeline.Context, results map[uint64]pipeline.Result) pipeline.Result {
 				assert.Error(t, results[0].Err)
 				return pipeline.Result{Err: results[0].Err}
 			})
@@ -64,7 +64,7 @@ func ExampleNewWorkerPoolStep() {
 				return pipeline.Result{}
 			}))
 		}
-	}, func(results map[uint64]pipeline.Result) pipeline.Result {
+	}, func(ctx pipeline.Context, results map[uint64]pipeline.Result) pipeline.Result {
 		for jobIndex, result := range results {
 			if result.IsFailed() {
 				fmt.Println(fmt.Sprintf("Job %d failed: %v", jobIndex, result.Err))

--- a/parallel/types.go
+++ b/parallel/types.go
@@ -12,14 +12,15 @@ import (
 type (
 	// ResultHandler is a callback that provides a result map and expect a single, combined pipeline.Result object.
 	// The map key is a zero-based index of n-th pipeline.Pipeline spawned, e.g. pipeline number 3 will have index 2.
+	// Context may be nil.
 	// Return an empty pipeline.Result if you want to ignore errors, or reduce multiple errors into a single one to make the parent pipeline fail.
-	ResultHandler func(results map[uint64]pipeline.Result) pipeline.Result
+	ResultHandler func(ctx pipeline.Context, results map[uint64]pipeline.Result) pipeline.Result
 	// PipelineSupplier is a function that spawns pipeline.Pipeline for consumption.
 	// The function must close the channel once all pipelines are spawned (`defer close()` recommended).
 	PipelineSupplier func(chan *pipeline.Pipeline)
 )
 
-func collectResults(handler ResultHandler, m *sync.Map) pipeline.Result {
+func collectResults(ctx pipeline.Context, handler ResultHandler, m *sync.Map) pipeline.Result {
 	collectiveResult := pipeline.Result{}
 	if handler != nil {
 		// convert sync.Map to conventional map for easier access
@@ -28,7 +29,7 @@ func collectResults(handler ResultHandler, m *sync.Map) pipeline.Result {
 			resultMap[key.(uint64)] = value.(pipeline.Result)
 			return true
 		})
-		collectiveResult = handler(resultMap)
+		collectiveResult = handler(ctx, resultMap)
 	}
 	return collectiveResult
 }

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -12,7 +12,7 @@ type hook struct {
 	calls int
 }
 
-func (h *hook) Accept(step Step) {
+func (h *hook) Accept(_ Step) {
 	h.calls += 1
 }
 
@@ -46,7 +46,7 @@ func TestPipeline_Run(t *testing.T) {
 			expectedCalls:   2,
 		},
 		"GivenPipelineWithFinalizer_WhenRunning_ThenCallHandler": {
-			givenFinalizer: func(result Result) error {
+			givenFinalizer: func(_ Context, result Result) error {
 				callCount += 1
 				return nil
 			},
@@ -67,7 +67,7 @@ func TestPipeline_Run(t *testing.T) {
 				NewStep("test-step", func(_ Context) Result {
 					callCount += 1
 					return Result{}
-				}).WithResultHandler(func(result Result) error {
+				}).WithResultHandler(func(_ Context, result Result) error {
 					callCount += 1
 					return errors.New("handler")
 				}),
@@ -84,7 +84,7 @@ func TestPipeline_Run(t *testing.T) {
 				NewStep("test-step", func(_ Context) Result {
 					callCount += 1
 					return Result{Err: errors.New("failed step")}
-				}).WithResultHandler(func(result Result) error {
+				}).WithResultHandler(func(_ Context, result Result) error {
 					callCount += 1
 					return nil
 				}),

--- a/predicate/predicate_test.go
+++ b/predicate/predicate_test.go
@@ -132,14 +132,14 @@ func TestWrapIn(t *testing.T) {
 }
 
 func truePredicate(counter *int) Predicate {
-	return func(step pipeline.Step) bool {
+	return func(_ pipeline.Context, step pipeline.Step) bool {
 		*counter++
 		return true
 	}
 }
 
 func falsePredicate(counter *int) Predicate {
-	return func(step pipeline.Step) bool {
+	return func(_ pipeline.Context, step pipeline.Step) bool {
 		*counter--
 		return false
 	}


### PR DESCRIPTION
## Summary

* adds `pipeline.Context` as an additional parameter to
  * `pipeline.ResultHandler`
  * `predicate.Predicate`
  * `parallel.ResultHandler`

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
