### PR TITLE
Add ErrAbort type that can terminate a pipeline without error

### DIFF
--- a/examples/abort_test.go
+++ b/examples/abort_test.go
@@ -1,0 +1,33 @@
+//go:build examples
+// +build examples
+
+package examples
+
+import (
+	"errors"
+	"testing"
+
+	pipeline "github.com/ccremer/go-command-pipeline"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExample_Abort(t *testing.T) {
+	p := pipeline.NewPipeline()
+	p.WithSteps(
+		pipeline.NewStepFromFunc("abort demo", abort),
+		pipeline.NewStepFromFunc("never executed", doNotExecute),
+	)
+	result := p.Run()
+	assert.True(t, result.IsSuccessful())
+}
+
+func doNotExecute(_ pipeline.Context) error {
+	return errors.New("should not execute")
+}
+
+func abort(_ pipeline.Context) error {
+	// some logic that can handle errors, but you don't want to bubble up the error.
+
+	// terminate pipeline gracefully
+	return pipeline.ErrAbort
+}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -62,6 +62,19 @@ func TestPipeline_Run(t *testing.T) {
 			expectedCalls:     1,
 			expectErrorString: "step failed",
 		},
+		"GivenStepWithErrAbort_WhenRunningWithErrAbort_ThenDoNotExecuteNextSteps": {
+			givenSteps: []Step{
+				NewStepFromFunc("test-step", func(_ Context) error {
+					callCount += 1
+					return ErrAbort
+				}),
+				NewStepFromFunc("step-should-not-execute", func(_ Context) error {
+					callCount += 1
+					return errors.New("should not execute")
+				}),
+			},
+			expectedCalls: 1,
+		},
 		"GivenSingleStepWithHandler_WhenRunningWithError_ThenAbortWithError": {
 			givenSteps: []Step{
 				NewStep("test-step", func(_ Context) Result {

--- a/result.go
+++ b/result.go
@@ -1,5 +1,10 @@
 package pipeline
 
+import "errors"
+
+// ErrAbort indicates that the pipeline should be terminated immediately without returning an error.
+var ErrAbort = errors.New("abort")
+
 // IsSuccessful returns true if the contained error is nil.
 func (r Result) IsSuccessful() bool {
 	return r.Err == nil


### PR DESCRIPTION
## Summary

* Adds `ErrAbort` special error type. This allows to cancel a pipeline if a step returns this error (or wrapped)

In case of error wrapping, a `ResultHandler` can unwrap the original error and do additional logic.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
