### PR TITLE
Rename predicate.WrapIn() to If()

### DIFF
--- a/predicate/predicate.go
+++ b/predicate/predicate.go
@@ -40,9 +40,9 @@ func ToNestedStep(name string, p *pipeline.Pipeline, predicate Predicate) pipeli
 	return step
 }
 
-// WrapIn returns a new step that wraps the given step and executes its action only if the given Predicate evaluates true.
+// If returns a new step that wraps the given step and executes its action only if the given Predicate evaluates true.
 // The pipeline.Context from the pipeline is passed through the given action.
-func WrapIn(originalStep pipeline.Step, predicate Predicate) pipeline.Step {
+func If(predicate Predicate, originalStep pipeline.Step) pipeline.Step {
 	wrappedStep := pipeline.Step{Name: originalStep.Name}
 	wrappedStep.F = func(ctx pipeline.Context) pipeline.Result {
 		if predicate(ctx, wrappedStep) {

--- a/predicate/predicate_test.go
+++ b/predicate/predicate_test.go
@@ -99,7 +99,7 @@ func TestToNestedStep(t *testing.T) {
 	}
 }
 
-func TestWrapIn(t *testing.T) {
+func TestIf(t *testing.T) {
 	counter := 0
 	tests := map[string]struct {
 		givenPredicate Predicate
@@ -122,7 +122,7 @@ func TestWrapIn(t *testing.T) {
 				counter++
 				return pipeline.Result{}
 			})
-			wrapped := WrapIn(step, tt.givenPredicate)
+			wrapped := If(tt.givenPredicate, step)
 			result := wrapped.F(nil)
 			require.NoError(t, result.Err)
 			assert.Equal(t, tt.expectedCalls, counter)


### PR DESCRIPTION
## Summary

* Renames `predicate.WrapIn()` to `predicate.If()`
* Changes signature of `predicate.If(...)` so that the parameters are interchanged.

This change makes it easier to read a nested pipeline like
```go
predicate.If(authenticated(), pipeline.NewStepFromFunc("query db", ...))
```

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
