### PR TITLE
Add BoolPtr() predicate

### DIFF
--- a/predicate/predicate.go
+++ b/predicate/predicate.go
@@ -54,9 +54,18 @@ func If(predicate Predicate, originalStep pipeline.Step) pipeline.Step {
 }
 
 // Bool returns a Predicate that simply returns v when evaluated.
+// Use BoolPtr() over Bool() if the value can change between setting up the pipeline and evaluating the predicate.
 func Bool(v bool) Predicate {
 	return func(_ pipeline.Context, step pipeline.Step) bool {
 		return v
+	}
+}
+
+// BoolPtr returns a Predicate that returns *v when evaluated.
+// Use BoolPtr() over Bool() if the value can change between setting up the pipeline and evaluating the predicate.
+func BoolPtr(v *bool) Predicate {
+	return func(_ pipeline.Context, _ pipeline.Step) bool {
+		return *v
 	}
 }
 

--- a/predicate/predicate_test.go
+++ b/predicate/predicate_test.go
@@ -131,6 +131,20 @@ func TestIf(t *testing.T) {
 	}
 }
 
+func TestBoolPtr(t *testing.T) {
+	called := false
+	b := false
+	p := pipeline.NewPipeline().WithSteps(
+		If(BoolPtr(&b), pipeline.NewStepFromFunc("boolptr", func(_ pipeline.Context) error {
+			called = true
+			return nil
+		})),
+	)
+	b = true
+	_ = p.Run()
+	assert.True(t, called)
+}
+
 func truePredicate(counter *int) Predicate {
 	return func(_ pipeline.Context, step pipeline.Step) bool {
 		*counter++


### PR DESCRIPTION
## Summary

* Adds `predicate.BoolPtr` as predicate to lazily evaluate a boolean.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
