### PR TITLE
Remove step parameter from Predicate signature

### DIFF
--- a/examples/git_test.go
+++ b/examples/git_test.go
@@ -61,7 +61,7 @@ func execGitCommand(args ...string) error {
 }
 
 func DirExists(path string) predicate.Predicate {
-	return func(ctx pipeline.Context, step pipeline.Step) bool {
+	return func(_ pipeline.Context) bool {
 		if info, err := os.Stat(path); err != nil || !info.IsDir() {
 			return false
 		}

--- a/predicate/predicate.go
+++ b/predicate/predicate.go
@@ -7,7 +7,7 @@ import (
 type (
 	// Predicate is a function that expects 'true' if a pipeline.ActionFunc should run.
 	// It is evaluated lazily resp. only when needed.
-	Predicate func(ctx pipeline.Context, step pipeline.Step) bool
+	Predicate func(ctx pipeline.Context) bool
 )
 
 // ToStep wraps the given action func in its own step.
@@ -17,7 +17,7 @@ type (
 func ToStep(name string, action pipeline.ActionFunc, predicate Predicate) pipeline.Step {
 	step := pipeline.Step{Name: name}
 	step.F = func(ctx pipeline.Context) pipeline.Result {
-		if predicate(ctx, step) {
+		if predicate(ctx) {
 			return action(ctx)
 		}
 		return pipeline.Result{}
@@ -29,10 +29,10 @@ func ToStep(name string, action pipeline.ActionFunc, predicate Predicate) pipeli
 // When the step's function is called, the given Predicate will evaluate whether the nested pipeline.Pipeline should actually run.
 // It returns the pipeline's pipeline.Result, otherwise an empty (successful) pipeline.Result struct.
 // The given pipeline has to define its own pipeline.Context, it's not passed "down".
-func ToNestedStep(name string, p *pipeline.Pipeline, predicate Predicate) pipeline.Step {
+func ToNestedStep(name string, predicate Predicate, p *pipeline.Pipeline) pipeline.Step {
 	step := pipeline.Step{Name: name}
 	step.F = func(ctx pipeline.Context) pipeline.Result {
-		if predicate(ctx, step) {
+		if predicate(ctx) {
 			return p.Run()
 		}
 		return pipeline.Result{}
@@ -45,7 +45,7 @@ func ToNestedStep(name string, p *pipeline.Pipeline, predicate Predicate) pipeli
 func If(predicate Predicate, originalStep pipeline.Step) pipeline.Step {
 	wrappedStep := pipeline.Step{Name: originalStep.Name}
 	wrappedStep.F = func(ctx pipeline.Context) pipeline.Result {
-		if predicate(ctx, wrappedStep) {
+		if predicate(ctx) {
 			return originalStep.F(ctx)
 		}
 		return pipeline.Result{}
@@ -56,7 +56,7 @@ func If(predicate Predicate, originalStep pipeline.Step) pipeline.Step {
 // Bool returns a Predicate that simply returns v when evaluated.
 // Use BoolPtr() over Bool() if the value can change between setting up the pipeline and evaluating the predicate.
 func Bool(v bool) Predicate {
-	return func(_ pipeline.Context, step pipeline.Step) bool {
+	return func(_ pipeline.Context) bool {
 		return v
 	}
 }
@@ -64,30 +64,30 @@ func Bool(v bool) Predicate {
 // BoolPtr returns a Predicate that returns *v when evaluated.
 // Use BoolPtr() over Bool() if the value can change between setting up the pipeline and evaluating the predicate.
 func BoolPtr(v *bool) Predicate {
-	return func(_ pipeline.Context, _ pipeline.Step) bool {
+	return func(_ pipeline.Context) bool {
 		return *v
 	}
 }
 
 // Not returns a Predicate that evaluates, but then negates the given Predicate.
 func Not(predicate Predicate) Predicate {
-	return func(ctx pipeline.Context, step pipeline.Step) bool {
-		return !predicate(ctx, step)
+	return func(ctx pipeline.Context) bool {
+		return !predicate(ctx)
 	}
 }
 
 // And returns a Predicate that does logical AND of the given predicates.
 // p2 is not evaluated if p1 evaluates already to false.
 func And(p1, p2 Predicate) Predicate {
-	return func(ctx pipeline.Context, step pipeline.Step) bool {
-		return p1(ctx, step) && p2(ctx, step)
+	return func(ctx pipeline.Context) bool {
+		return p1(ctx) && p2(ctx)
 	}
 }
 
 // Or returns a Predicate that does logical OR of the given predicates.
 // p2 is not evaluated if p1 evaluates already to true.
 func Or(p1, p2 Predicate) Predicate {
-	return func(ctx pipeline.Context, step pipeline.Step) bool {
-		return p1(ctx, step) || p2(ctx, step)
+	return func(ctx pipeline.Context) bool {
+		return p1(ctx) || p2(ctx)
 	}
 }

--- a/predicate/predicate_test.go
+++ b/predicate/predicate_test.go
@@ -92,7 +92,7 @@ func TestToNestedStep(t *testing.T) {
 				counter++
 				return pipeline.Result{}
 			}))
-			step := ToNestedStep("super step", p, tt.givenPredicate)
+			step := ToNestedStep("super step", tt.givenPredicate, p)
 			_ = step.F(nil)
 			assert.Equal(t, tt.expectedCounts, counter)
 		})
@@ -146,14 +146,14 @@ func TestBoolPtr(t *testing.T) {
 }
 
 func truePredicate(counter *int) Predicate {
-	return func(_ pipeline.Context, step pipeline.Step) bool {
+	return func(_ pipeline.Context) bool {
 		*counter++
 		return true
 	}
 }
 
 func falsePredicate(counter *int) Predicate {
-	return func(_ pipeline.Context, step pipeline.Step) bool {
+	return func(_ pipeline.Context) bool {
 		*counter--
 		return false
 	}


### PR DESCRIPTION
## Summary

* Removes parameter `step` from `predicate.Predicate`

Experiences using this predicate showed no value for the step parameter.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
