### PR TITLE
Change pipeline hook type to plain func instead of interface

### DIFF
--- a/examples/hooks_test.go
+++ b/examples/hooks_test.go
@@ -10,15 +10,11 @@ import (
 	pipeline "github.com/ccremer/go-command-pipeline"
 )
 
-type PipelineLogger struct{}
-
-func (l *PipelineLogger) Accept(step pipeline.Step) {
-	fmt.Println(fmt.Sprintf("Executing step: %s", step.Name))
-}
-
 func TestExample_Hooks(t *testing.T) {
 	p := pipeline.NewPipeline()
-	p.AddBeforeHook(&PipelineLogger{})
+	p.AddBeforeHook(func(step pipeline.Step) {
+		fmt.Println(fmt.Sprintf("Executing step: %s", step.Name))
+	})
 	p.WithSteps(
 		pipeline.NewStep("hook demo", AfterHookAction()),
 	)

--- a/pipeline.go
+++ b/pipeline.go
@@ -38,11 +38,8 @@ type (
 	}
 	// Context contains arbitrary data relevant for the pipeline execution.
 	Context interface{}
-	// Listener is a simple interface that listens to Pipeline events.
-	Listener interface {
-		// Accept takes the given Step.
-		Accept(step Step)
-	}
+	// Listener is a simple func that listens to Pipeline events.
+	Listener func(step Step)
 	// ActionFunc is the func that contains your business logic.
 	// The context is a user-defined arbitrary data of type interface{} that gets provided in every Step, but may be nil if not set.
 	ActionFunc func(ctx Context) Result
@@ -132,8 +129,8 @@ func (p *Pipeline) Run() Result {
 
 func (p *Pipeline) doRun() Result {
 	for _, step := range p.steps {
-		for _, listener := range p.beforeHooks {
-			listener.Accept(step)
+		for _, hooks := range p.beforeHooks {
+			hooks(step)
 		}
 
 		result := step.F(p.context)

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -42,7 +42,7 @@ func TestPipeline_Run(t *testing.T) {
 					return Result{}
 				}),
 			},
-			givenBeforeHook: hook,
+			givenBeforeHook: hook.Accept,
 			expectedCalls:   2,
 		},
 		"GivenPipelineWithFinalizer_WhenRunning_ThenCallHandler": {


### PR DESCRIPTION


## Summary

* `Listener` is not an interface with `Accept(step)` anymore, but `func(step)`.

This makes anonymous hooks easier to implement

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
