### PR TITLE
Add option to disable error wrapping

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,0 +1,21 @@
+package pipeline
+
+// Option configures the given Pipeline with a behaviour-altering setting.
+type Option func(pipeline *Pipeline)
+
+// WithOptions configures the Pipeline with settings.
+// The options are applied immediately.
+// Options are applied to nested pipelines provided they are set before building the nested pipeline.
+// Nested pipelines can be configured with their own options.
+func (p *Pipeline) WithOptions(options ...Option) *Pipeline {
+	for _, option := range options {
+		option(p)
+	}
+	return p
+}
+
+// DisableErrorWrapping disables the wrapping of errors that are emitted from pipeline steps.
+// This effectively causes Result.Err to be exactly the error as returned from a step.
+var DisableErrorWrapping Option = func(pipeline *Pipeline) {
+	pipeline.disableErrorWrapping = true
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,22 @@
+package pipeline
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPipeline_WithOptions(t *testing.T) {
+	t.Run("DisableErrorWrapping", func(t *testing.T) {
+		p := NewPipeline().WithOptions(DisableErrorWrapping)
+		p.WithSteps(
+			NewStepFromFunc("disabled error wrapping", func(_ Context) error {
+				return errors.New("some error")
+			}),
+		)
+		assert.True(t, p.disableErrorWrapping)
+		result := p.Run()
+		assert.Equal(t, "some error", result.Err.Error())
+	})
+}


### PR DESCRIPTION


## Summary

* Adds `Pipeline.WithOptions(options...)` method.
* Adds `DisableErrorWrapping` option func to disable error wrapping.
* Options are passed down to wrapped pipelines. provided they are set before building a nested pipeline.

Sometimes implementations may want to transparently run code without wrapping errors from a library.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
