### PR TITLE
Add IsAborted query in results

### DIFF
--- a/examples/abort_test.go
+++ b/examples/abort_test.go
@@ -19,6 +19,7 @@ func TestExample_Abort(t *testing.T) {
 	)
 	result := p.Run()
 	assert.True(t, result.IsSuccessful())
+	assert.True(t, result.IsAborted())
 }
 
 func doNotExecute(_ pipeline.Context) error {

--- a/pipeline.go
+++ b/pipeline.go
@@ -17,10 +17,13 @@ type (
 	// Result is the object that is returned after each step and after running a pipeline.
 	Result struct {
 		// Err contains the step's returned error, nil otherwise.
+		// In an aborted pipeline with ErrAbort it will still be nil.
 		Err error
 		// Name is an optional identifier for a result.
 		// ActionFunc may set this property before returning to help a ResultHandler with further processing.
 		Name string
+
+		aborted bool
 	}
 	// Step is an intermediary action and part of a Pipeline.
 	Step struct {
@@ -144,7 +147,7 @@ func (p *Pipeline) doRun() Result {
 		if err != nil {
 			if errors.Is(err, ErrAbort) {
 				// Abort pipeline without error
-				return Result{}
+				return Result{aborted: true}
 			}
 			if p.disableErrorWrapping {
 				return Result{Err: err}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -20,11 +20,12 @@ func TestPipeline_Run(t *testing.T) {
 	callCount := 0
 	hook := &hook{}
 	tests := map[string]struct {
-		givenSteps        []Step
-		givenBeforeHook   Listener
-		givenFinalizer    ResultHandler
-		expectErrorString string
-		expectedCalls     int
+		givenSteps           []Step
+		givenBeforeHook      Listener
+		givenFinalizer       ResultHandler
+		expectErrorString    string
+		expectedCalls        int
+		additionalAssertions func(t *testing.T, result Result)
 	}{
 		"GivenSingleStep_WhenRunning_ThenCallStep": {
 			givenSteps: []Step{
@@ -74,6 +75,9 @@ func TestPipeline_Run(t *testing.T) {
 				}),
 			},
 			expectedCalls: 1,
+			additionalAssertions: func(t *testing.T, result Result) {
+				assert.True(t, result.IsAborted())
+			},
 		},
 		"GivenSingleStepWithHandler_WhenRunningWithError_ThenAbortWithError": {
 			givenSteps: []Step{
@@ -153,6 +157,9 @@ func TestPipeline_Run(t *testing.T) {
 				assert.True(t, actualResult.IsSuccessful())
 			}
 			assert.Equal(t, tt.expectedCalls, callCount)
+			if tt.additionalAssertions != nil {
+				tt.additionalAssertions(t, actualResult)
+			}
 		})
 	}
 }

--- a/result.go
+++ b/result.go
@@ -6,6 +6,8 @@ import "errors"
 var ErrAbort = errors.New("abort")
 
 // IsSuccessful returns true if the contained error is nil.
+// Aborted pipelines (with ErrAbort) are still reported as success.
+// To query if a pipeline is aborted early, use IsAborted.
 func (r Result) IsSuccessful() bool {
 	return r.Err == nil
 }
@@ -13,4 +15,9 @@ func (r Result) IsSuccessful() bool {
 // IsFailed returns true if the contained error is non-nil.
 func (r Result) IsFailed() bool {
 	return r.Err != nil
+}
+
+// IsAborted returns true if the pipeline didn't stop with an error, but just aborted early with ErrAbort.
+func (r Result) IsAborted() bool {
+	return r.aborted
 }


### PR DESCRIPTION
## Summary

* Adds `IsAborted` to `Result`

Follow-up of #21 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
