### PR TITLE
Rework Result's Error property

### DIFF
--- a/examples/context_test.go
+++ b/examples/context_test.go
@@ -27,7 +27,7 @@ func TestExample_Context(t *testing.T) {
 	)
 	result := p.RunWithContext(context.WithValue(context.Background(), key, &Data{}))
 	if !result.IsSuccessful() {
-		t.Fatal(result.Err)
+		t.Fatal(result.Err())
 	}
 }
 

--- a/examples/git_test.go
+++ b/examples/git_test.go
@@ -23,33 +23,33 @@ func TestExample_Git(t *testing.T) {
 	)
 	result := p.Run()
 	if !result.IsSuccessful() {
-		t.Fatal(result.Err)
+		t.Fatal(result.Err())
 	}
 }
 
 func logSuccess(_ context.Context, result pipeline.Result) error {
 	log.Println("handler called")
-	return result.Err
+	return result.Err()
 }
 
 func CloneGitRepository() pipeline.ActionFunc {
 	return func(_ context.Context) pipeline.Result {
 		err := execGitCommand("clone", "git@github.com/ccremer/go-command-pipeline")
-		return pipeline.Result{Err: err}
+		return pipeline.NewResultWithError("clone repository", err)
 	}
 }
 
 func Pull() pipeline.ActionFunc {
 	return func(_ context.Context) pipeline.Result {
 		err := execGitCommand("pull")
-		return pipeline.Result{Err: err}
+		return pipeline.NewResultWithError("pull", err)
 	}
 }
 
 func CheckoutBranch() pipeline.ActionFunc {
 	return func(_ context.Context) pipeline.Result {
 		err := execGitCommand("checkout", "master")
-		return pipeline.Result{Err: err}
+		return pipeline.NewResultWithError("checkout branch", err)
 	}
 }
 

--- a/examples/hooks_test.go
+++ b/examples/hooks_test.go
@@ -21,7 +21,7 @@ func TestExample_Hooks(t *testing.T) {
 	)
 	result := p.Run()
 	if !result.IsSuccessful() {
-		t.Fatal(result.Err)
+		t.Fatal(result.Err())
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -18,6 +18,6 @@ func TestPipeline_WithOptions(t *testing.T) {
 		)
 		assert.True(t, p.options.disableErrorWrapping)
 		result := p.Run()
-		assert.Equal(t, "some error", result.Err.Error())
+		assert.Equal(t, "some error", result.Err().Error())
 	})
 }

--- a/parallel/resulthandler.go
+++ b/parallel/resulthandler.go
@@ -29,12 +29,11 @@ func collectResults(ctx context.Context, handler ResultHandler, m *sync.Map) pip
 
 func setResultErrorFromContext(ctx context.Context, result pipeline.Result) pipeline.Result {
 	if ctx.Err() != nil {
-		if result.Err != nil {
-			result.Err = fmt.Errorf("%w, collection error: %v", ctx.Err(), result.Err)
-			return pipeline.Canceled(result)
+		if result.Err() != nil {
+			err := fmt.Errorf("%w, collection error: %v", ctx.Err(), result.Err())
+			return pipeline.NewResult(result.Name(), err, result.IsAborted(), true)
 		}
-		result.Err = ctx.Err()
-		return pipeline.Canceled(result)
+		return pipeline.NewResult(result.Name(), ctx.Err(), result.IsAborted(), true)
 	}
 	return result
 }

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -60,7 +60,7 @@ func TestPipeline_Run(t *testing.T) {
 			givenSteps: []Step{
 				NewStep("test-step", func(_ context.Context) Result {
 					callCount += 1
-					return Result{Err: errors.New("step failed")}
+					return Result{err: errors.New("step failed")}
 				}),
 			},
 			expectedCalls:     1,
@@ -103,7 +103,7 @@ func TestPipeline_Run(t *testing.T) {
 			givenSteps: []Step{
 				NewStep("test-step", func(_ context.Context) Result {
 					callCount += 1
-					return Result{Err: errors.New("failed step")}
+					return Result{err: errors.New("failed step")}
 				}).WithResultHandler(func(_ context.Context, result Result) error {
 					callCount += 1
 					return nil
@@ -152,11 +152,11 @@ func TestPipeline_Run(t *testing.T) {
 			}
 			actualResult := p.Run()
 			if tt.expectErrorString != "" {
-				require.Error(t, actualResult.Err)
+				require.Error(t, actualResult.Err())
 				assert.True(t, actualResult.IsFailed())
-				assert.Contains(t, actualResult.Err.Error(), tt.expectErrorString)
+				assert.Contains(t, actualResult.Err().Error(), tt.expectErrorString)
 			} else {
-				assert.NoError(t, actualResult.Err)
+				assert.NoError(t, actualResult.Err())
 				assert.True(t, actualResult.IsSuccessful())
 			}
 			assert.Equal(t, tt.expectedCalls, callCount)
@@ -188,7 +188,7 @@ func TestPipeline_RunWithContext_CancelLongRunningStep(t *testing.T) {
 	result := p.RunWithContext(ctx)
 	assert.True(t, result.IsCanceled(), "IsCanceled()")
 	assert.Equal(t, "long running", result.Name())
-	assert.EqualError(t, result.Err, "step \"long running\" failed: context canceled")
+	assert.EqualError(t, result.Err(), "step \"long running\" failed: context canceled")
 }
 
 func ExamplePipeline_RunWithContext() {
@@ -211,7 +211,7 @@ func ExamplePipeline_RunWithContext() {
 	result := p.RunWithContext(ctx)
 	// inspect the result
 	fmt.Println(result.IsCanceled())
-	fmt.Println(result.Err)
+	fmt.Println(result.Err())
 	// Output: short step
 	// true
 	// step "canceled step" failed: context deadline exceeded

--- a/predicate/predicate.go
+++ b/predicate/predicate.go
@@ -22,7 +22,7 @@ func ToStep(name string, action pipeline.ActionFunc, predicate Predicate) pipeli
 		if predicate(ctx) {
 			return action(ctx)
 		}
-		return pipeline.Result{}
+		return pipeline.NewEmptyResult(name)
 	}
 	return step
 }
@@ -37,7 +37,7 @@ func ToNestedStep(name string, predicate Predicate, p *pipeline.Pipeline) pipeli
 		if predicate(ctx) {
 			return p.Run()
 		}
-		return pipeline.Result{}
+		return pipeline.NewEmptyResult(name)
 	}
 	return step
 }
@@ -50,7 +50,7 @@ func If(predicate Predicate, originalStep pipeline.Step) pipeline.Step {
 		if predicate(ctx) {
 			return originalStep.F(ctx)
 		}
-		return pipeline.Result{}
+		return pipeline.NewEmptyResult(originalStep.Name)
 	}
 	return wrappedStep
 }

--- a/predicate/predicate_test.go
+++ b/predicate/predicate_test.go
@@ -65,7 +65,7 @@ func Test_Predicates(t *testing.T) {
 			}, tt.givenPredicate)
 			result := step.F(nil)
 			assert.Equal(t, tt.expectedCounts, counter)
-			assert.NoError(t, result.Err)
+			assert.NoError(t, result.Err())
 		})
 	}
 }
@@ -125,7 +125,7 @@ func TestIf(t *testing.T) {
 			})
 			wrapped := If(tt.givenPredicate, step)
 			result := wrapped.F(nil)
-			require.NoError(t, result.Err)
+			require.NoError(t, result.Err())
 			assert.Equal(t, tt.expectedCalls, counter)
 			assert.Equal(t, step.Name, wrapped.Name)
 		})

--- a/result.go
+++ b/result.go
@@ -7,13 +7,35 @@ var ErrAbort = errors.New("abort")
 
 // Result is the object that is returned after each step and after running a pipeline.
 type Result struct {
-	// Err contains the step's returned error, nil otherwise.
-	// In an aborted pipeline with ErrAbort it will still be nil.
-	Err error
-
+	err      error
 	name     string
 	aborted  bool
 	canceled bool
+}
+
+// NewEmptyResult returns a Result with just the name.
+func NewEmptyResult(stepName string) Result {
+	return Result{
+		name: stepName,
+	}
+}
+
+// NewResult is the constructor for all properties.
+func NewResult(stepName string, err error, aborted, canceled bool) Result {
+	return Result{
+		name:     stepName,
+		err:      err,
+		aborted:  aborted,
+		canceled: canceled,
+	}
+}
+
+// NewResultWithError constructs a Result with given name and error.
+func NewResultWithError(stepName string, err error) Result {
+	return Result{
+		name: stepName,
+		err:  err,
+	}
 }
 
 // Name retrieves the name of the (last) step that has been executed.
@@ -21,16 +43,22 @@ func (r Result) Name() string {
 	return r.name
 }
 
+// Err contains the step's returned error, nil otherwise.
+// In an aborted pipeline with ErrAbort it will still be nil.
+func (r Result) Err() error {
+	return r.err
+}
+
 // IsSuccessful returns true if the contained error is nil.
 // Aborted pipelines (with ErrAbort) are still reported as success.
 // To query if a pipeline is aborted early, use IsAborted.
 func (r Result) IsSuccessful() bool {
-	return r.Err == nil
+	return r.err == nil
 }
 
 // IsFailed returns true if the contained error is non-nil.
 func (r Result) IsFailed() bool {
-	return r.Err != nil
+	return r.err != nil
 }
 
 // IsAborted returns true if the pipeline didn't stop with an error, but just aborted early with ErrAbort.
@@ -41,10 +69,4 @@ func (r Result) IsAborted() bool {
 // IsCanceled returns true if the pipeline's context has been canceled.
 func (r Result) IsCanceled() bool {
 	return r.canceled
-}
-
-// Canceled sets Result.IsCanceled to true.
-func Canceled(result Result) Result {
-	result.canceled = true
-	return result
 }

--- a/step.go
+++ b/step.go
@@ -14,7 +14,7 @@ func NewStep(name string, action ActionFunc) Step {
 func NewStepFromFunc(name string, fn func(ctx context.Context) error) Step {
 	return NewStep(name, func(ctx context.Context) Result {
 		err := fn(ctx)
-		return Result{Err: err, name: name}
+		return NewResult(name, err, false, false)
 	})
 }
 
@@ -29,7 +29,7 @@ func (s Step) WithResultHandler(handler ResultHandler) Step {
 func (s Step) WithErrorHandler(errorHandler func(ctx context.Context, err error) error) Step {
 	s.H = func(ctx context.Context, result Result) error {
 		if result.IsFailed() {
-			return errorHandler(ctx, result.Err)
+			return errorHandler(ctx, result.Err())
 		}
 		return nil
 	}

--- a/step_test.go
+++ b/step_test.go
@@ -31,7 +31,7 @@ func TestStep_WithErrorHandler(t *testing.T) {
 				executed = true
 				return err
 			})
-			err := s.H(nil, Result{Err: tt.givenError})
+			err := s.H(nil, Result{err: tt.givenError})
 			assert.Equal(t, tt.givenError, err)
 			assert.Equal(t, tt.expectedExecution, executed)
 		})


### PR DESCRIPTION
## Summary

This PR makes the `Result.Err` a function instead of exported property. This change clearly makes it visible that the `Result` is not meant to be modified after running a pipeline.
Numerous new constructors should make it possible to safely create the `Result` in steps.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
