### PR TITLE
Add wrapper to store and retrieve values in context

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,47 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+type contextKey struct{}
+
+// VariableContext adds a map to the given context that can be used to store intermediate values in the context.
+// It uses sync.Map under the hood.
+//
+// See also AddToContext() and ValueFromContext.
+func VariableContext(parent context.Context) context.Context {
+	return context.WithValue(parent, contextKey{}, &sync.Map{})
+}
+
+// AddToContext adds the given key and value to ctx.
+// Any keys or values added during pipeline execution is available in the next steps, provided the pipeline runs synchronously.
+// In parallel executed pipelines you may encounter race conditions.
+// Use ValueFromContext to retrieve values.
+//
+// Note: This method is thread-safe, but panics if ctx has not been set up with VariableContext first.
+func AddToContext(ctx context.Context, key, value interface{}) {
+	m := ctx.Value(contextKey{})
+	if m == nil {
+		panic(errors.New("context was not set up with VariableContext()"))
+	}
+	m.(*sync.Map).Store(key, value)
+}
+
+// ValueFromContext returns the value from the given context with the given key.
+// It returns the value and true, or nil and false if the key doesn't exist.
+// It may return nil and true if the key exists, but the value actually is nil.
+// Use AddToContext to store values.
+//
+// Note: This method is thread-safe, but panics if the ctx has not been set up with VariableContext first.
+func ValueFromContext(ctx context.Context, key interface{}) (interface{}, bool) {
+	m := ctx.Value(contextKey{})
+	if m == nil {
+		panic(errors.New("context was not set up with VariableContext()"))
+	}
+	mp := m.(*sync.Map)
+	val, found := mp.Load(key)
+	return val, found
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,72 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContext(t *testing.T) {
+	tests := map[string]struct {
+		givenKey      interface{}
+		givenValue    interface{}
+		expectedValue interface{}
+		expectedFound bool
+	}{
+		"GivenNonExistentKey_ThenExpectNilAndFalse": {
+			givenKey:      nil,
+			expectedValue: nil,
+		},
+		"GivenKeyWithNilValue_ThenExpectNilAndTrue": {
+			givenKey:      "key",
+			givenValue:    nil,
+			expectedValue: nil,
+			expectedFound: true,
+		},
+		"GivenKeyWithValue_ThenExpectValueAndTrue": {
+			givenKey:      "key",
+			givenValue:    "value",
+			expectedValue: "value",
+			expectedFound: true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := VariableContext(context.Background())
+			if tc.givenKey != nil {
+				AddToContext(ctx, tc.givenKey, tc.givenValue)
+			}
+			result, found := ValueFromContext(ctx, tc.givenKey)
+			assert.Equal(t, tc.expectedValue, result, "value")
+			assert.Equal(t, tc.expectedFound, found, "value found")
+		})
+	}
+}
+
+func TestContextPanics(t *testing.T) {
+	assert.PanicsWithError(t, "context was not set up with VariableContext()", func() {
+		AddToContext(context.Background(), "key", "value")
+	}, "AddToContext")
+	assert.PanicsWithError(t, "context was not set up with VariableContext()", func() {
+		ValueFromContext(context.Background(), "key")
+	}, "ValueFromContext")
+}
+
+func ExampleVariableContext() {
+	ctx := VariableContext(context.Background())
+	p := NewPipeline().WithSteps(
+		NewStepFromFunc("store value", func(ctx context.Context) error {
+			AddToContext(ctx, "key", "value")
+			return nil
+		}),
+		NewStepFromFunc("retrieve value", func(ctx context.Context) error {
+			value, _ := ValueFromContext(ctx, "key")
+			fmt.Println(value)
+			return nil
+		}),
+	)
+	p.RunWithContext(ctx)
+	// Output: value
+}


### PR DESCRIPTION
## Summary

* Adds `VariableContext`, `AddToContext`, `ValueFromContext` functions

Usage example: 
https://github.com/ccremer/go-command-pipeline/blob/d0821c232fc95f7198bbe7edeeea7529866f88ce/context_test.go#L58-L70

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
