### PR TITLE
Rename VariableContext to MutableContext

### DIFF
--- a/context.go
+++ b/context.go
@@ -8,38 +8,42 @@ import (
 
 type contextKey struct{}
 
-// VariableContext adds a map to the given context that can be used to store intermediate values in the context.
+// MutableContext adds a map to the given context that can be used to store mutable values in the context.
 // It uses sync.Map under the hood.
+// Repeated calls to MutableContext with the same parent has no effect and returns the same context.
 //
-// See also AddToContext() and ValueFromContext.
-func VariableContext(parent context.Context) context.Context {
-	return context.WithValue(parent, contextKey{}, &sync.Map{})
+// See also StoreInContext and LoadFromContext.
+func MutableContext(parent context.Context) context.Context {
+	if parent.Value(contextKey{}) == nil {
+		return context.WithValue(parent, contextKey{}, &sync.Map{})
+	}
+	return parent
 }
 
-// AddToContext adds the given key and value to ctx.
+// StoreInContext adds the given key and value to ctx.
 // Any keys or values added during pipeline execution is available in the next steps, provided the pipeline runs synchronously.
 // In parallel executed pipelines you may encounter race conditions.
-// Use ValueFromContext to retrieve values.
+// Use LoadFromContext to retrieve values.
 //
-// Note: This method is thread-safe, but panics if ctx has not been set up with VariableContext first.
-func AddToContext(ctx context.Context, key, value interface{}) {
+// Note: This method is thread-safe, but panics if ctx has not been set up with MutableContext first.
+func StoreInContext(ctx context.Context, key, value interface{}) {
 	m := ctx.Value(contextKey{})
 	if m == nil {
-		panic(errors.New("context was not set up with VariableContext()"))
+		panic(errors.New("context was not set up with MutableContext()"))
 	}
 	m.(*sync.Map).Store(key, value)
 }
 
-// ValueFromContext returns the value from the given context with the given key.
+// LoadFromContext returns the value from the given context with the given key.
 // It returns the value and true, or nil and false if the key doesn't exist.
 // It may return nil and true if the key exists, but the value actually is nil.
-// Use AddToContext to store values.
+// Use StoreInContext to store values.
 //
-// Note: This method is thread-safe, but panics if the ctx has not been set up with VariableContext first.
-func ValueFromContext(ctx context.Context, key interface{}) (interface{}, bool) {
+// Note: This method is thread-safe, but panics if the ctx has not been set up with MutableContext first.
+func LoadFromContext(ctx context.Context, key interface{}) (interface{}, bool) {
 	m := ctx.Value(contextKey{})
 	if m == nil {
-		panic(errors.New("context was not set up with VariableContext()"))
+		panic(errors.New("context was not set up with MutableContext()"))
 	}
 	mp := m.(*sync.Map)
 	val, found := mp.Load(key)


### PR DESCRIPTION


## Summary

* Renames `VariableContext` to `MutableContext`
* Also ensure that calls to MutableContext can be repeated.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
