### PR TITLE
MustLoadFromContext now panics if the key is not present

### DIFF
--- a/context.go
+++ b/context.go
@@ -26,7 +26,7 @@ func MutableContext(parent context.Context) context.Context {
 // Use LoadFromContext to retrieve values.
 //
 // Note: This method is thread-safe, but panics if ctx has not been set up with MutableContext first.
-func StoreInContext(ctx context.Context, key, value interface{}) {
+func StoreInContext(ctx context.Context, key, value any) {
 	m := ctx.Value(contextKey{})
 	if m == nil {
 		panic(fmt.Errorf("context was not set up with MutableContext()"))
@@ -40,7 +40,7 @@ func StoreInContext(ctx context.Context, key, value interface{}) {
 // Use StoreInContext to store values.
 //
 // Note: This method is thread-safe, but panics if the ctx has not been set up with MutableContext first.
-func LoadFromContext(ctx context.Context, key interface{}) (interface{}, bool) {
+func LoadFromContext(ctx context.Context, key any) (any, bool) {
 	m := ctx.Value(contextKey{})
 	if m == nil {
 		panic(fmt.Errorf("context was not set up with MutableContext()"))
@@ -55,10 +55,22 @@ func LoadFromContext(ctx context.Context, key interface{}) (interface{}, bool) {
 // Use StoreInContext to store values.
 //
 // Note: This method is thread-safe, but panics if the ctx has not been set up with MutableContext first.
-func MustLoadFromContext(ctx context.Context, key interface{}) interface{} {
+func MustLoadFromContext(ctx context.Context, key any) any {
 	val, found := LoadFromContext(ctx, key)
 	if !found {
 		panic(fmt.Errorf("key %q was not found in context", key))
+	}
+	return val
+}
+
+// LoadFromContextOrDefault is similar to MustLoadFromContext, except it returns the given default value if the key doesn't exist.
+// Use StoreInContext to store values.
+//
+// Note: This method is thread-safe, but panics if the ctx has not been set up with MutableContext first.
+func LoadFromContextOrDefault(ctx context.Context, key any, defValue any) any {
+	val, found := LoadFromContext(ctx, key)
+	if !found {
+		return defValue
 	}
 	return val
 }

--- a/context_test.go
+++ b/context_test.go
@@ -83,6 +83,20 @@ func TestMustLoadFromContext(t *testing.T) {
 	})
 }
 
+func TestLoadFromContextOrDefault(t *testing.T) {
+	t.Run("KeyExists", func(t *testing.T) {
+		ctx := MutableContext(context.Background())
+		StoreInContext(ctx, "key", "value")
+		result := LoadFromContextOrDefault(ctx, "key", "default")
+		assert.Equal(t, "value", result)
+	})
+	t.Run("KeyDoesntExist", func(t *testing.T) {
+		ctx := MutableContext(context.Background())
+		result := LoadFromContextOrDefault(ctx, "key", "default")
+		assert.Equal(t, "default", result)
+	})
+}
+
 func ExampleMutableContext() {
 	type key struct{}
 

--- a/context_test.go
+++ b/context_test.go
@@ -70,9 +70,10 @@ func TestMustLoadFromContext(t *testing.T) {
 		assert.Nil(t, result)
 	})
 	t.Run("KeyDoesntExist", func(t *testing.T) {
-		ctx := MutableContext(context.Background())
-		result := MustLoadFromContext(ctx, "key")
-		assert.Nil(t, result)
+		assert.PanicsWithError(t, `key "key" was not found in context`, func() {
+			ctx := MutableContext(context.Background())
+			_ = MustLoadFromContext(ctx, "key")
+		})
 	})
 	t.Run("KeyExistsWithValue", func(t *testing.T) {
 		ctx := MutableContext(context.Background())


### PR DESCRIPTION
## Summary

This actually conforms to the usual "must" convention.
Besides, returning nil if a key is not found only hides the root cause when troubleshooting
nil pointer panics.

Users that depend on previous behaviour (returning nil or default value) can now use new function `LoadFromContextOrDefault` and pass a default value that is returned in case of inexisting key.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
