### PR TITLE
Rework step conditional execution

### DIFF
--- a/examples/git_test.go
+++ b/examples/git_test.go
@@ -20,7 +20,7 @@ type GitContext struct {
 func TestExample_Git(t *testing.T) {
 	p := pipeline.NewPipeline[context.Context]()
 	p.WithSteps(
-		p.If(pipeline.Not(DirExists("my-repo")),
+		p.When(pipeline.Not(DirExists("my-repo")),
 			"clone repository", CloneGitRepository(),
 		),
 		p.NewStep("checkout branch", CheckoutBranch()),

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -118,7 +118,7 @@ func TestPipeline_RunWithContext(t *testing.T) {
 		"GivenNestedPipeline_WhenParentPipelineRuns_ThenRunNestedAsWell_Variant2": {
 			givenSteps: []Step[*testContext]{
 				NewPipeline[*testContext]().
-					WithNestedSteps("nested-pipeline",
+					WithNestedSteps("nested-pipeline", nil,
 						NewStep[*testContext]("nested-step", func(ctx *testContext) error {
 							ctx.count += 1
 							return nil
@@ -216,6 +216,15 @@ func ExamplePipeline_RunWithContext() {
 	fmt.Println(err)
 	// Output: hello world
 	// step 'canceled step' failed: context deadline exceeded
+}
+
+func ExamplePipeline_When() {
+	p := NewPipeline[context.Context]()
+	p.WithSteps(
+		p.When(Bool[context.Context](true), "run", func(ctx context.Context) error {
+			return nil
+		}),
+	)
 }
 
 type testContext struct {

--- a/predicate.go
+++ b/predicate.go
@@ -9,64 +9,6 @@ import (
 // Predicate should be idempotent, meaning multiple invocations return the same result and without side effects.
 type Predicate[T context.Context] func(ctx T) bool
 
-// ToStep wraps the given action func in its own step.
-// When the step's function is called, the given Predicate will evaluate whether the action should actually run.
-// It returns the action's Result, otherwise an empty (successful) Result.
-// The context.Context from the pipeline is passed through the given action.
-func ToStep[T context.Context](name string, action ActionFunc[T], predicate Predicate[T]) Step[T] {
-	step := Step[T]{Name: name}
-	step.Action = func(ctx T) error {
-		if predicate(ctx) {
-			return action(ctx)
-		}
-		return nil
-	}
-	return step
-}
-
-// ToNestedStep wraps the given pipeline in its own step.
-// When the step's function is called, the given Predicate will evaluate whether the nested Pipeline should actually run.
-// It returns the pipeline's Result, otherwise an empty (successful) Result struct.
-// The given pipeline has to define its own context.Context, it's not passed "down".
-func ToNestedStep[T context.Context](name string, predicate Predicate[T], p *Pipeline[T]) Step[T] {
-	step := Step[T]{Name: name}
-	step.Action = func(ctx T) error {
-		if predicate(ctx) {
-			return p.RunWithContext(ctx)
-		}
-		return nil
-	}
-	return step
-}
-
-// If returns a new step that wraps the given step and executes its action only if the given Predicate evaluates true.
-// The context.Context from the pipeline is passed through the given action.
-func If[T context.Context](predicate Predicate[T], originalStep Step[T]) Step[T] {
-	wrappedStep := Step[T]{Name: originalStep.Name}
-	wrappedStep.Action = func(ctx T) error {
-		if predicate(ctx) {
-			return originalStep.Action(ctx)
-		}
-		return nil
-	}
-	return wrappedStep
-}
-
-// IfOrElse returns a new step that wraps the given steps and executes its action based on the given Predicate.
-// The name of the step is taken from `trueStep`.
-// The context.Context from the pipeline is passed through the given actions.
-func IfOrElse[T context.Context](predicate Predicate[T], trueStep Step[T], falseStep Step[T]) Step[T] {
-	wrappedStep := Step[T]{Name: trueStep.Name}
-	wrappedStep.Action = func(ctx T) error {
-		if predicate(ctx) {
-			return trueStep.Action(ctx)
-		} else {
-			return falseStep.Action(ctx)
-		}
-	}
-	return wrappedStep
-}
-
 // Bool returns a Predicate that simply returns v when evaluated.
 // Use BoolPtr() over Bool() if the value can change between setting up the pipeline and evaluating the predicate.
 func Bool[T context.Context](v bool) Predicate[T] {

--- a/step.go
+++ b/step.go
@@ -19,6 +19,9 @@ type Step[T context.Context] struct {
 	// The function may return nil even if the given error is non-nil, in which case the pipeline will continue.
 	// This function is called before the next step's Action is invoked.
 	Handler ErrorHandler[T]
+	// Condition determines if the Step's Action is actually going to be executed in the pipeline.
+	// When nil, the Action is executed.
+	Condition Predicate[T]
 }
 
 // NewStep returns a new Step with given name and action.
@@ -32,8 +35,20 @@ func NewStep[T context.Context](name string, action ActionFunc[T]) Step[T] {
 	}
 }
 
+// NewStepIf is syntactic sugar for NewStep with Step.When.
+func NewStepIf[T context.Context](predicate Predicate[T], name string, actionFunc ActionFunc[T]) Step[T] {
+	return NewStep[T](name, actionFunc).When(predicate)
+}
+
 // WithErrorHandler sets the ErrorHandler of this specific step and returns the step itself.
 func (s Step[T]) WithErrorHandler(errorHandler ErrorHandler[T]) Step[T] {
 	s.Handler = errorHandler
+	return s
+}
+
+// When sets Step.Condition.
+// When the given predicate returns false, the step is skipped without error.
+func (s Step[T]) When(predicate Predicate[T]) Step[T] {
+	s.Condition = predicate
 	return s
 }


### PR DESCRIPTION
## Summary

Predicates wrapping steps doesn't quite feel right. For instance, previous `If` implementation created an additional step that had the same name as for the step that would be executed if it evaluated to `true`.

This PR makes conditional and predicates first-class citizen in the pipeline. `Step` has now a new field `Condition Predicate[T]`. If set, the pipeline will evaluate the condition prior to executing a Step's `Action()`.

Change summary:

* `pipeline.If` is removed. use `NewStep(...).When(predicate)` instead.
* `pipeline.IfOrElse` is removed, use `NewStep(...).When(pipeline.Not(predicate)` instead.
* New method `Pipeline.When(predicate, name, action`
* New func `NewStepIf(predicate, name, action)`
* New method `Step.When(predicate)`
* `Pipeline.WithNestedSteps` has now `Predicate[T]` in the signature. It accepts nil as well.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
