### PR TITLE
Implement Unwrap for Result errors

### DIFF
--- a/result.go
+++ b/result.go
@@ -30,3 +30,8 @@ func (r resultImpl) Error() string {
 func (r resultImpl) Name() string {
 	return r.name
 }
+
+// Unwrap implements xerrors.Wrapper.
+func (r resultImpl) Unwrap() error {
+	return r.err
+}


### PR DESCRIPTION
## Summary

Small feature that adds `Unwrap()` for `Result` (making more use of Go 1.13 error handling)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
